### PR TITLE
Custom extend

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,7 +307,7 @@ function namespace(name) {
       }
     };
 
-    Ctor.prototype.mixins = Ctor.prototype.mixins || [];
+    Ctor.prototype.mixins = [];
     Ctor.mixin = function(fn) {
       var mixin = fn(Ctor.prototype);
       if (typeof mixin === 'function') {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "class-utils": "^0.2.2",
+    "class-utils": "^0.3.0",
     "collection-visit": "^0.2.1",
     "component-emitter": "^1.2.0",
     "define-property": "^0.2.5",

--- a/test.js
+++ b/test.js
@@ -128,6 +128,7 @@ describe('static properties', function() {
     it('should set the mixin method on the given object:', function() {
       function Ctor() {}
       Base.extend(Ctor);
+      assert(typeof Base.mixin === 'function');
       assert(typeof Ctor.mixin === 'function');
     });
 
@@ -136,14 +137,19 @@ describe('static properties', function() {
         Base.call(this);
       }
       Base.extend(Ctor);
-
-      var inst = new Ctor();
-      Ctor.mixin(function(proto) {
+      Base.mixin(function(proto) {
         proto.foo = 'bar';
       });
 
-      assert(Ctor.prototype.foo === 'bar');
+      var inst = new Ctor();
+      Ctor.mixin(function(proto) {
+        proto.bar = 'baz';
+      });
+
+      assert(Base.prototype.foo === 'bar');
+      assert(Ctor.prototype.bar === 'baz');
       assert(inst.foo === 'bar');
+      assert(inst.bar === 'baz');
     });
   });
 
@@ -160,16 +166,16 @@ describe('static properties', function() {
         Base.call(this);
       }
       Base.extend(Ctor);
-      Ctor.mixin(function() {
-        return function (proto) {
-          proto.bar = 'bar';
-        };
+      Base.mixin(function fn(proto) {
+        proto.bar = 'bar';
+        return fn;
       });
 
       function Child() {
         Ctor.call(this);
       }
-      Ctor.extend(Child);
+      Base.extend(Child);
+      Base.mixins(Child);
       Ctor.mixins(Child);
 
       var inst = new Child();

--- a/test.js
+++ b/test.js
@@ -123,6 +123,60 @@ describe('static properties', function() {
       assert(typeof bar.bar.bar === 'undefined');
     });
   });
+
+  describe('mixin', function() {
+    it('should set the mixin method on the given object:', function() {
+      function Ctor() {}
+      Base.extend(Ctor);
+      assert(typeof Ctor.mixin === 'function');
+    });
+
+    it('should use a globally loaded mixin through the static mixin method:', function() {
+      function Ctor() {
+        Base.call(this);
+      }
+      Base.extend(Ctor);
+
+      var inst = new Ctor();
+      Ctor.mixin(function(proto) {
+        proto.foo = 'bar';
+      });
+
+      assert(Ctor.prototype.foo === 'bar');
+      assert(inst.foo === 'bar');
+    });
+  });
+
+  describe('mixins', function() {
+    it('should set the mixins method on the given object:', function() {
+      function Ctor() {}
+      Base.extend(Ctor);
+      assert(typeof Ctor.mixins === 'function');
+    });
+
+    it('should use a globally loaded mixin through the static mixins method:', function() {
+
+      function Ctor() {
+        Base.call(this);
+      }
+      Base.extend(Ctor);
+      Ctor.mixin(function() {
+        return function (proto) {
+          proto.bar = 'bar';
+        };
+      });
+
+      function Child() {
+        Ctor.call(this);
+      }
+      Ctor.extend(Child);
+      Ctor.mixins(Child);
+
+      var inst = new Child();
+      assert(Child.prototype.bar === 'bar');
+      assert(inst.bar === 'bar');
+    });
+  });
 });
 
 describe('extend prototype methods', function() {

--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,6 @@ utils.run = function(obj, prop, arr) {
   }
 };
 
-
 /**
  * Expose `utils` modules
  */

--- a/utils.js
+++ b/utils.js
@@ -39,6 +39,23 @@ require('class-utils', 'cu');
 require = fn; // eslint-disable-line
 
 /**
+ * Run an array of functions by passing each function
+ * to a method on the given object specified by the given property.
+ *
+ * @param  {Object} `obj` Object containing method to use.
+ * @param  {String} `prop` Name of the method on the object to use.
+ * @param  {Array} `arr` Array of functions to pass to the method.
+ */
+
+utils.run = function(obj, prop, arr) {
+  var len = arr.length, i = 0;
+  while (len--) {
+    obj[prop](arr[i++]);
+  }
+};
+
+
+/**
  * Expose `utils` modules
  */
 


### PR DESCRIPTION
Updating to use the new changes in `class-utils` and pass in a custom extend method.
Custom extend method adds the follow:
- [x] `mixin` on the prototype for instances.
- [x] `mixin` as a static method for adding mixins like using plugins.
- [x] `mixins` for running over registered mixin plugins and applying them to the given child Ctor.
