### PR TITLE
Bug in singleton + docs fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function namespace(name) {
   }
 
   /**
-   * Create an instance of `Base` with `options`.
+   * Create an instance of `Base` with `config` and `options`.
    *
    * ```js
    * var app = new Base();
@@ -22,6 +22,7 @@ function namespace(name) {
    * //=> 'bar'
    * ```
    *
+   * @param {Object} `config` passed to [cache-base][]
    * @param {Object} `options`
    * @api public
    */

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function namespace(name) {
 
   function Base(config, options) {
     if (!(this instanceof Base)) {
-      return new Base(config);
+      return new Base(config, options);
     }
     Cache.call(this, config);
     this.initBase(config, options);

--- a/index.js
+++ b/index.js
@@ -16,10 +16,20 @@ function namespace(name) {
    * Create an instance of `Base` with `config` and `options`.
    *
    * ```js
-   * var app = new Base();
+   * var app = new Base({baz: 'qux'}, {yeah: 123, nope: 456});
+   *
    * app.set('foo', 'bar');
-   * console.log(app.get('foo'));
-   * //=> 'bar'
+   *
+   * console.log(app.get('foo')); //=> 'bar'
+   * console.log(app.get('baz')); //=> 'qux'
+   * console.log(app.get('yeah')); //=> undefined
+   *
+   * console.log(app.foo); //=> 'bar'
+   * console.log(app.baz); //=> 'qux'
+   * console.log(app.yeah); //=> undefined
+   *
+   * console.log(app.options.yeah); //=> 123
+   * console.log(app.options.nope); //=> 456
    * ```
    *
    * @param {Object} `config` passed to [cache-base][]


### PR DESCRIPTION
Separate commits for each thing.

Bug appears when you call base without `new` keyword for example

``` js
var base = require('base')
var app = base({baz: 'qux'}, {yeah: 123, nope: 456})

app.set('foo', 'bar')
console.log(app.foo) // => 'bar'
console.log(app.baz) // => 'qux'

console.log(app.get('foo')) // => 'bar'
console.log(app.get('baz')) // => 'qux'

console.log(app.yeah) // => undefined
console.log(app.nope) // => undefined
console.log(app.options) // => {}
```

calling it with `new Base()` works as expected (and as in tests) without this PR.
