### PR TITLE
lint, update namespace/debug to be plugins, and their logic

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var Base = require('./index');
+
+function Templates() {
+  Base.call(this);
+  this.is('templates');
+}
+Base.extend(Templates);
+
+function Assemble() {
+  Templates.call(this);
+  this.is('assemble');
+}
+Templates.extend(Assemble);
+
+function Generate() {
+  Assemble.call(this);
+  this.is('generate');
+}
+Assemble.extend(Generate);
+
+function Verb() {
+  Generate.call(this);
+  this.is('verb');
+}
+Generate.extend(Verb);
+
+var verb = new Verb();
+
+console.log(verb._namespace);
+//=> base:templates:assemble:generate:verb
+
+var one = verb.debug('one');
+one('debugging with %s Mike Reagent', 'Charlike');
+//=> base:templates:assemble:generate:verb:one debugging with %s Mike Reagent
+
+verb.debug.helper('loading foo helper');
+//=> base:templates:assemble:generate:verb:helper loading foo helper
+
+verb.debug('foo:bar', 123, 'baz:qux', 'zaz')('hello world');
+//=> base:templates:assemble:generate:verb:foo:bar:baz:qux:zaz hello world
+
+var templates = new Templates();
+templates.debug('one:two', 'three:four')('okey, that is awesome');
+//=> base:templates:one:two:three:four okey, that is awesome

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var debug = require('debug');
 var util = require('util');
 
 function namespace(name) {
@@ -96,19 +95,31 @@ function namespace(name) {
 
   Base.prototype.is = function(name) {
     var parent = (this._namespace || this._name || '').toLowerCase();
-
     name = name.toLowerCase();
+
     this.define('is' + utils.pascal(name), true);
     this.define('_name', name);
     this.define('_appname', name);
+    this.define('_namespace', name);
 
-    this.define('_namespace', this._name);
-    utils.namespace(this, parent);
-    this.define('debug', debug(this._namespace));
-
-    this.debug.append = function(prop) {
-      this.namespace = parent + ':' + prop;
-    };
+    // internal plugins
+    this.use(utils.namespacePlugin(parent));
+    this.use(utils.debugPlugin([
+      'collection',
+      'context',
+      'engine',
+      'helper',
+      'helpers',
+      'item',
+      'layout',
+      'list',
+      'lookup',
+      'plugin',
+      'render',
+      'routes',
+      'view',
+      'views'
+    ]));
     return this;
   };
 

--- a/index.js
+++ b/index.js
@@ -104,22 +104,7 @@ function namespace(name) {
 
     // internal plugins
     this.use(utils.namespacePlugin(parent));
-    this.use(utils.debugPlugin([
-      'collection',
-      'context',
-      'engine',
-      'helper',
-      'helpers',
-      'item',
-      'layout',
-      'list',
-      'lookup',
-      'plugin',
-      'render',
-      'routes',
-      'view',
-      'views'
-    ]));
+    this.use(utils.debugPlugin());
     return this;
   };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "gulp"
   },
   "dependencies": {
     "arr-union": "^3.1.0",
@@ -43,8 +43,7 @@
     "gulp-istanbul": "^0.10.3",
     "gulp-mocha": "^2.2.0",
     "helper-coverage": "^0.1.3",
-    "mocha": "*",
-    "should": "*"
+    "mocha": "*"
   },
   "keywords": [
     "boilerplate",

--- a/test.js
+++ b/test.js
@@ -314,7 +314,7 @@ describe('prototype methods', function() {
     });
 
     it('should debug without arguments be base namespace', function() {
-      var app = base.debug()('foo bar baz')
+      var app = base.debug()('foo bar baz');
       assert.equal(app._namespace, 'base');
       assert.equal(base._namespace, 'base');
       assert.equal(app._debugNamespace, 'base');

--- a/test.js
+++ b/test.js
@@ -321,17 +321,6 @@ describe('prototype methods', function() {
       assert.equal(base._debugNamespace, 'base');
     });
 
-    it('should have built-in debug namespaced methods', function() {
-      var app = new Base();
-      var foo = app.debug.helper('loading foo helper');
-
-      assert.equal(app._debugNamespace, 'base:helper');
-      assert.equal(foo._debugNamespace, 'base:helper');
-      assert.notEqual(app._debugNamespace, app._namespace);
-      assert.notEqual(app._debugNamespace, foo._namespace);
-      assert.notEqual(foo._debugNamespace, foo._namespace);
-    });
-
     it('should not double-append the same child namespace', function() {
       function Foo() {
         Base.call(this);
@@ -399,30 +388,6 @@ describe('prototype methods', function() {
 
       var baz = new Baz();
       assert.equal(baz._debugNamespace, 'base:foo:bar:baz');
-    });
-
-    it.skip('should append a custom debug namespace', function() {
-      function Foo() {
-        Base.call(this);
-        this.is('foo');
-      }
-      Base.extend(Foo);
-
-      function Bar() {
-        Foo.call(this);
-        this.is('bar');
-      }
-      Foo.extend(Bar);
-
-      function Baz() {
-        Bar.call(this);
-        this.is('baz');
-        this.debug.append('a:b:c');
-      }
-      Bar.extend(Baz);
-
-      var baz = new Baz();
-      assert.equal(baz.debug.namespace, 'base:foo:bar:baz:a:b:c');
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -1,10 +1,7 @@
 'use strict';
 
-require('mocha');
-require('should');
 var assert = require('assert');
-var utils = require('./utils');
-var Base = require('./');
+var Base = require('./index');
 var base;
 
 describe('constructor', function() {
@@ -312,68 +309,120 @@ describe('prototype methods', function() {
       assert.equal(typeof base.debug, 'function');
     });
 
-    it('should append child namespaces', function() {
-      function Foo(options) {
-        Base.call(this, null, options);
-        this.is('foo');
-      }
-      Base.extend(Foo);
+    it('should debug return a `debug` function', function() {
+      assert.equal(typeof base.debug('one'), 'function');
+    });
 
-      function Bar(options) {
-        Foo.call(this, options);
-        this.is('bar');
-      }
-      Foo.extend(Bar);
+    it('should debug without arguments be base namespace', function() {
+      var app = base.debug()('foo bar baz')
+      assert.equal(app._namespace, 'base');
+      assert.equal(base._namespace, 'base');
+      assert.equal(app._debugNamespace, 'base');
+      assert.equal(base._debugNamespace, 'base');
+    });
 
-      var bar = new Bar();
-      assert.equal(bar.debug.namespace, 'base:foo:bar');
+    it('should have built-in debug namespaced methods', function() {
+      var app = new Base();
+      var foo = app.debug.helper('loading foo helper');
+
+      assert.equal(app._debugNamespace, 'base:helper');
+      assert.equal(foo._debugNamespace, 'base:helper');
+      assert.notEqual(app._debugNamespace, app._namespace);
+      assert.notEqual(app._debugNamespace, foo._namespace);
+      assert.notEqual(foo._debugNamespace, foo._namespace);
     });
 
     it('should not double-append the same child namespace', function() {
-      function Foo(options) {
-        Base.call(this, null, options);
+      function Foo() {
+        Base.call(this);
         this.is('foo');
       }
       Base.extend(Foo);
 
-      function Bar(options) {
-        Foo.call(this, options);
+      function Bar() {
+        Foo.call(this);
         this.is('bar');
       }
       Foo.extend(Bar);
 
-      function Baz(options) {
-        Bar.call(this, options);
+      function Baz() {
+        Bar.call(this);
         this.is('bar');
       }
       Bar.extend(Baz);
 
       var baz = new Baz();
-      assert.equal(baz.debug.namespace, 'base:foo:bar');
+      assert.equal(baz._debugNamespace, 'base:foo:bar');
     });
 
-    it('should append a custom debug namespace', function() {
-      function Foo(options) {
-        Base.call(this, null, options);
+    it('should `debug` method return a new `debug` function', function() {
+      var one = base.debug('one');
+      var app1 = one('that is okey');
+      assert.equal(typeof one, 'function');
+      assert.equal(app1._debugNamespace, 'base:one');
+
+      /**
+       * Be careful with the order of calling the things
+       * if you move this two lines above respectively
+       * below `one` and below `app1`, then `app1._debugNamespace`
+       * will fail, that's logical.
+       *
+       * More guaranteed is always to lookup `app._namespace`, it is
+       * real app namespace, but not the `debug` namespace.
+       * One is sure, debug namespace is bigger and always starts
+       * with `app._namespace`.
+       */
+      var two = base.debug('one:two', 123, 'three', 'four:five');
+      var app2 = two('that is awesome');
+      assert.equal(typeof two, 'function');
+      assert.equal(app2._debugNamespace, 'base:one:two:three:four:five');
+    });
+
+    it('should append child namespaces', function() {
+      function Foo() {
+        Base.call(this);
         this.is('foo');
       }
       Base.extend(Foo);
 
-      function Bar(options) {
-        Foo.call(this, options);
+      function Bar() {
+        Foo.call(this);
         this.is('bar');
       }
       Foo.extend(Bar);
 
-      function Baz(options) {
-        Bar.call(this, options);
+      function Baz() {
+        Bar.call(this);
+        this.is('baz');
+      }
+      Bar.extend(Baz);
+
+      var baz = new Baz();
+      assert.equal(baz._debugNamespace, 'base:foo:bar:baz');
+    });
+
+    it.skip('should append a custom debug namespace', function() {
+      function Foo() {
+        Base.call(this);
+        this.is('foo');
+      }
+      Base.extend(Foo);
+
+      function Bar() {
+        Foo.call(this);
         this.is('bar');
+      }
+      Foo.extend(Bar);
+
+      function Baz() {
+        Bar.call(this);
+        this.is('baz');
         this.debug.append('a:b:c');
       }
       Bar.extend(Baz);
 
       var baz = new Baz();
-      assert.equal(baz.debug.namespace, 'base:foo:bar:a:b:c');
+      assert.equal(baz.debug.namespace, 'base:foo:bar:baz:a:b:c');
     });
   });
 

--- a/utils.js
+++ b/utils.js
@@ -35,13 +35,90 @@ utils.pascal = function(name) {
   return name.charAt(0).toUpperCase() + name.slice(1);
 };
 
-utils.namespace = function(app, parent) {
-  var parentSegs = parent ? parent.split(':') : [];
-  var segs = app._name.split(':');
+/**
+ * Plugins, should be moved out
+ */
 
-  var namespace = utils.union([], parentSegs, segs);
-  app._namespace = namespace.join(':');
+utils.namespacePlugin = function namespacePlugin(parent) {
+  return function plugin(app) {
+    parent = typeof parent === 'string' && parent.length ? parent : false;
+
+    var parentSegs = parent ? parent.split(':') : [];
+    var nameSegs = app._name.split(':');
+    var namespace = utils.union([], parentSegs, nameSegs);
+
+    app.define('_namespace', namespace.join(':'));
+  };
 };
+
+/**
+ * Plugin that adds `debug` method to the instance
+ * and `namespaces` are added to this method.
+ *
+ * ```js
+ * app.debug()('debugging on main namespace')
+ * //=> base debugging on main namespace
+ *
+ * app.debug.one = app.debug('one')
+ * app.debug.one('testing %s, whatever', 'foo, bar')
+ * //=> base:one testing foo, bar, whatever
+ *
+ * app.debug.mix = app.debug('two', 123 'three:four', 'five')
+ * app.debug.mix('okey, %s awesome', 'this is')
+ * //=> base:two:three:four:five okey, this is awesome
+ *
+ * app.debug.helper('is one of internal namespaces added')
+ * //=> base:helper is one of internal namespaces added
+ * ```
+ *
+ * @name   .debug
+ * @param  {Array} `namespaces`
+ * @return {Function}
+ */
+
+utils.debugPlugin = function debugPlugin(namespaces) {
+  namespaces = Array.isArray(namespaces) ? namespaces : [namespaces];
+
+  return function plugin(app) {
+    app.define('_debugNamespace', app._namespace);
+    app.define('debug', function debug() {
+      return debugFactory.apply(app, arguments);
+    });
+    if (namespaces.length) {
+      var len = namespaces.length
+      var i = 0
+
+      while (i < len) {
+        var ns = namespaces[i++];
+        app.debug[ns] = debugFactory.call(app, ns);
+        app.debug[ns].color = app.debug.color;
+      }
+    }
+  };
+};
+
+function debugFactory() {
+  var app = this;
+  var args = [].slice.call(arguments);
+  var segs = app._namespace.split(':');
+  var len = args.length;
+  var i = 0;
+
+  while (i < len) {
+    var val = args[i++];
+    if (typeof val === 'string') {
+      segs.push.apply(segs, val.split(':'));
+    }
+  }
+
+  return function debug() {
+    var fn = require('debug');
+    var namespace = segs.join(':');
+    app.define('_debugNamespace', namespace);
+    fn(namespace).apply(fn, arguments);
+    return app;
+  };
+}
 
 /**
  * Expose `utils` modules

--- a/utils.js
+++ b/utils.js
@@ -85,8 +85,8 @@ utils.debugPlugin = function debugPlugin(namespaces) {
       return debugFactory.apply(app, arguments);
     });
     if (namespaces.length) {
-      var len = namespaces.length
-      var i = 0
+      var len = namespaces.length;
+      var i = 0;
 
       while (i < len) {
         var ns = namespaces[i++];


### PR DESCRIPTION
- `should` removed - not used anywhere.
- `mocha` require removed - blocks us, we all have it globally.
- test script to `gulp`, maybe would revert it, but it's a good thing anyway
- update and add new tests for the debugging stuff
- `app._namespace` is more stable now
- add `app._debugNamespace`, because we can't just overwrite `_namespace` from debug plugin, or we can it would be unnecessary bonus job.
- no need of `Constructor.debug` thingy and then calling it from app's constructur with `debug(this)`
- **everything is handled and works automagically**, you can't believe, lol
- battle tested, lol - meaning, local verb and any of the others works with it
- the instance `debug` method accept string arguments, and also support splitting by `:`
- add built-in debug methods e.g. `this.debug.helper`, `this.debug.view`, etc
- builtin methods does not accept namespaces, because they are namespaces
- if you want another namespace just use `app.debug.my = app.debug('one')`
- you can control the built-ins, they also can be overwritten if the APP add the plugin manually
- and yes, i think `namespace` should be separate plugin
- and yes, there are a little diff and logic between `_debugNamespace` and `_namespace` 

**example.js**

``` js
'use strict';

var Base = require('./index');

function Templates() {
  Base.call(this);
  this.is('templates');
}
Base.extend(Templates);

function Assemble() {
  Templates.call(this);
  this.is('assemble');
}
Templates.extend(Assemble);

function Generate() {
  Assemble.call(this);
  this.is('generate');
}
Assemble.extend(Generate);

function Verb() {
  Generate.call(this);
  this.is('verb');
}
Generate.extend(Verb);

var verb = new Verb();

console.log(verb._namespace);
//=> base:templates:assemble:generate:verb

var one = verb.debug('one');
one('debugging with %s Mike Reagent', 'Charlike');
//=> base:templates:assemble:generate:verb:one debugging with Charlike Mike Reagent

verb.debug.helper('loading foo helper');
//=> base:templates:assemble:generate:verb:helper loading foo helper

verb.debug('foo:bar', 123, 'baz:qux', 'zaz')('hello world');
//=> base:templates:assemble:generate:verb:foo:bar:baz:qux:zaz hello world

var templates = new Templates();
templates.debug('one:two', 'three:four')('okey, that is awesome');
//=> base:templates:one:two:three:four okey, that is awesome

```

I can PR to base-debug, templates, assemble, generate and verb to get the change (it would be just removeing the `debug(this)` thing from their constructors). And we should create `base-namespace`.
