### PR TITLE
Updating documentation for Base function

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function namespace(name) {
    * app.set('foo', 'bar');
    *
    * // values defined with the given `config` object will be on the root of the instance
-   * console.log(app.baz); //=> true
+   * console.log(app.baz); //=> undefined
    * console.log(app.foo); //=> 'bar'
    * // or use `.get`
    * console.log(app.get('isApp')); //=> true


### PR DESCRIPTION
`console.log(app.baz);` returns undefined
