### PR TITLE
Update mixin-deep to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cache-base": "^4.0.0",
     "define-property": "^2.0.2",
     "kind-of": "^6.0.2",
-    "mixin-deep": "^1.3.1",
+    "mixin-deep": "^2.0.1",
     "pascalcase": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update mixin-deep to 2.0.1.

Per mixin-deep -  "Please update to version 2.0.1 or later, a critical bug was fixed in that version."

https://github.com/jonschlinkert/mixin-deep