### PR TITLE
Updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - ppc64le
 language: node_js
 node_js:
   - node


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing.
For more info tag @gerrith3.